### PR TITLE
Squash docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+dist: trusty
+sudo: required
+
+language: ruby
+
+env:
+  global:
+  - secure: "fLPGlg6qKERKJyqd4gSoYYY8H4XFiQoeCqIxAzrpWOxZsZke2n3zTu+U9mK3sG9uxZigWg7Cbb8D2DJmRZ6Lu/WDCx/sTRDF2E63dmibE5ST8rDwgxFH9TuVrOlUfa4+NdPtjLvbVm1yh7OVRdsBScw+VJ10ikV6jdT8YZSVeSaLitfPLzH1hwzJdvW1YWyIXNHaoYJRuoY621judzmopeXYdGLsGqcL7JtmSgU2um3HIKKbqkuqDMpyLlsCB6PlCnalaj6C86QFLo1hjUSKfahP+4lORSyshoytZWO+CkCAoaJz8hZA5yuUs5NlK25S4JFUZmFvTgsgWMuiZ+qvrjShd8GY33GSW4idYXRbgyVWocDzkTRjsNoLWbzPDlmLpPUqdxvtMhft+8TkUbyxcPJVfGj4q4iMWeQTO+bee8ymFn/azqLW1lFlylWkVd5Ex6IY7MpHXAFI/wjD5yceUJD2lWYSsxekPSFoFVKs/Yx0N0KKbIsgB+WphH81eHAW3U3pIiOJAmoxI47sWFYrViYkov6o7QUIbRLiL6IqpdI5/uNOnT1Xcr+X11WA+IyLlHgwqQ6nOXhNbuViVBS49Q+W6Vd4NFxKh773osmXl10p4NKEj5jlHpvwShyNjkJFDGvNIOEsm7vHsXZCVq745QMl6KNu+g36iazx06KA2NU=" # DOCKER_USER
+  - secure: "Ofa/clrc1pB8ZPDu/l9XG2vF8TezNKOhLR/3h2FfMRo7YeV/c8GofKNRfU9VO5HNlRZsYcAwEJwsO/+MmNGZT9VNkjedH6iqnbkHcJQGKND5/TnXiJPua5cKQ4L4KS6zv/2WLLk3d7zkrmiU3DB8apLN+enBqdSWkFoQxdVcZyhcR8YdWg4Qgu650F64gfDsCRACDnNVMiVHyqQH2mdxAiVjC9CHGgMSH2GOInYwUANSc92xJAwbQMB/gYXnJ+QFcRs8Gpve/NOX4brr2hhjwFm00DIHzJgK/JAelmka9HqASUvz5R1cDaNU7x02Wt1zGslSkQgwWXI3UaRO48W2JM2NFxIAb7Bz8SVPULuDAlFN/5HFDSOrmnTH3aIZFfZ/Hm/uvYDgWEizF+GUA83MM7cHx6hphA8WsZ2ALG3ozqgP3vP4Rq3phL9i5f5054icxTARs2/UbHPgn7A4O+Cwp/hEMvv4M8Lk/ezCnLQA5iTljsk/mtFwy7Ne65UBxb/8S+F1BpqxHwrx5yDlOEVJ8EDzbBHv6otG0ApphNk1ccvfP/fCACMuDY2gEcOS1EVuF2aey5y3mKlUPnz1KOpYzXvjtln7z4KfFsHHaFDFwJqtXRlmxto4rliryBZ9fsIug+wfRrC7VSA4JMcFkEeJclbJcpoE1MVDjUAVaRo7YkA=" # DOCKER_PASS
+
+install: true # skip
+
+before_script: make build
+
+script: make test
+
+before_deploy: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+
+deploy:
+  provider: script
+  script: make release
+  on:
+    tags: true
+    all_branches: true
+

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,6 @@ release: build
 	docker tag $(IMAGE):latest $(IMAGE):$(MAJOR_VERSION)
 	docker push $(IMAGE):$(MAJOR_VERSION)
 
-test:
+test: build
 	./test.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all build release
 
+IMAGE := goodeggs/ranch-baseimage-nodejs
 VERSION := $(shell cat VERSION)
 MAJOR_VERSION := $(shell awk -F. '{print $$1}' VERSION)
 MINOR_VERSION := $(shell awk -F. '{print $$2}' VERSION)
@@ -7,21 +8,21 @@ MINOR_VERSION := $(shell awk -F. '{print $$2}' VERSION)
 all: build
 
 build:
-	docker build --squash -t goodeggs/ranch-baseimage-nodejs .
+	docker build -t $(IMAGE):latest .
 
-release:
+release: build
 	echo $(VERSION)
 	echo $(MAJOR_VERSION)
 	echo $(MINOR_VERSION)
 	( git diff --quiet && git diff --cached --quiet ) || ( echo "checkout must be clean"; false )
-	docker build --squash -t goodeggs/ranch-baseimage-nodejs:latest .
-	docker push goodeggs/ranch-baseimage-nodejs:latest
-	docker tag goodeggs/ranch-baseimage-nodejs:latest goodeggs/ranch-baseimage-nodejs:$(VERSION)
-	docker push goodeggs/ranch-baseimage-nodejs:$(VERSION)
-	docker tag goodeggs/ranch-baseimage-nodejs:latest goodeggs/ranch-baseimage-nodejs:$(MAJOR_VERSION).$(MINOR_VERSION)
-	docker push goodeggs/ranch-baseimage-nodejs:$(MAJOR_VERSION).$(MINOR_VERSION)
-	docker tag goodeggs/ranch-baseimage-nodejs:latest goodeggs/ranch-baseimage-nodejs:$(MAJOR_VERSION)
-	docker push goodeggs/ranch-baseimage-nodejs:$(MAJOR_VERSION)
+	docker run -ti -v /var/run/docker.sock:/var/run/docker.sock goodeggs/docker-squash $(IMAGE):latest
+	docker push $(IMAGE):latest
+	docker tag $(IMAGE):latest $(IMAGE):$(VERSION)
+	docker push $(IMAGE):$(VERSION)
+	docker tag $(IMAGE):latest $(IMAGE):$(MAJOR_VERSION).$(MINOR_VERSION)
+	docker push $(IMAGE):$(MAJOR_VERSION).$(MINOR_VERSION)
+	docker tag $(IMAGE):latest $(IMAGE):$(MAJOR_VERSION)
+	docker push $(IMAGE):$(MAJOR_VERSION)
 
 test:
 	./test.sh

--- a/test.sh
+++ b/test.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-set -o errexit    # always exit on error
-set -o pipefail   # don't ignore exit codes when piping output
-set -o nounset    # fail on unset variables
+set -e
+set -o pipefail
 
-image_id=${1-""}
+image_id="$1"
 
 if [[ -z "$image_id" ]]; then
-  docker build -t foo .
+  docker build -t goodeggs/ranch-baseimage-nodejs:latest .
   
-  cd `mktemp -d`
+  cd "$(mktemp -d)"
   
   cat > Dockerfile <<EOF
-FROM foo
+FROM goodeggs/ranch-baseimage-nodejs:latest
 EOF
   
   cat > package.json <<EOF
@@ -47,7 +46,7 @@ EOF
   
   docker build --build-arg 'RANCH_BUILD_ENV={}' . | tee docker.log
   
-  image_id=`tail -n1 docker.log | awk '{print $3}'`
+  image_id=$(tail -n1 docker.log | awk '{print $3}')
 fi
 
 function assert_equal {
@@ -63,7 +62,7 @@ function assert_equal {
 }
 
 function run {
-  docker run --rm -i $image_id "$@"
+  docker run --rm -i "$image_id" "$@"
 }
 
 function main {


### PR DESCRIPTION
Use [docker-squash](https://github.com/goodeggs/docker-squash) on release images so we've got one layer to ship around.  Saves a few MB, but negligible.

Also includes enabling tests on Travis and releases on new tags (managed with `gitsem` and the [VERSION](https://github.com/goodeggs/ranch-baseimage-nodejs/blob/master/VERSION) file).
